### PR TITLE
Add HFL include

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+Debug
+Release
+*.suo
+*.user
+*.aps
+.vs

--- a/DllMain.cpp
+++ b/DllMain.cpp
@@ -1,0 +1,18 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <HFL/Source/HFL.h>
+
+BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
+{
+	if (fdwReason == DLL_PROCESS_ATTACH)
+	{
+		HFLInit();
+		DisableThreadLibraryCalls(hinstDLL);
+	}
+	else if (fdwReason == DLL_PROCESS_DETACH)
+    {
+        HFLCleanup();
+    }
+
+    return true;
+}

--- a/DllMain.cpp
+++ b/DllMain.cpp
@@ -10,9 +10,9 @@ BOOL APIENTRY DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 		DisableThreadLibraryCalls(hinstDLL);
 	}
 	else if (fdwReason == DLL_PROCESS_DETACH)
-    {
-        HFLCleanup();
-    }
+	{
+		HFLCleanup();
+	}
 
-    return true;
+	return true;
 }

--- a/OP2Script.vcxproj
+++ b/OP2Script.vcxproj
@@ -19,14 +19,14 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/OP2Script.vcxproj
+++ b/OP2Script.vcxproj
@@ -84,9 +84,13 @@
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="DllMain.cpp" />
     <ClCompile Include="LevelMain.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="OP2MissionSDK\HFL\Source\HFL.vcxproj">
+      <Project>{0fc43a25-fb89-4258-849b-cb3c0a061e0d}</Project>
+    </ProjectReference>
     <ProjectReference Include="OP2MissionSDK\OP2Helper\OP2Helper.vcxproj">
       <Project>{0b520c87-4cfd-4a4d-abd4-f87d26df9aad}</Project>
     </ProjectReference>

--- a/OP2Script.vcxproj.filters
+++ b/OP2Script.vcxproj.filters
@@ -18,5 +18,8 @@
     <ClCompile Include="LevelMain.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="DllMain.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #3

Note that the user would still have to add an include for HFL in their project files to use it. With this code, HFL is guaranteed to be initialized correctly though so others don't make the mistake that I did.