### PR TITLE
Save build artifacts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,3 +7,10 @@ install:
   - git submodule update --init --recursive
 build:
   project: OP2Script.sln
+after_build:
+  - set PackageBaseName="%APPVEYOR_PROJECT_NAME%-Build%APPVEYOR_BUILD_VERSION%-%CONFIGURATION%"
+  - 7z a "%PackageBaseName%.zip" "%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.dll"
+  - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.pdb"
+artifacts:
+  - path: "*.zip"
+    name: BuildArtifacts


### PR DESCRIPTION
Have AppVeyor CI builds save a copy of the build artifacts. These can be used as a basis for forming a GitHub release. These builds come from a standardized clean build environment, with a publicized build procedure and known source version, which could avoid issues with viruses, local malicious tampering, or accidental local modifications. It also allows for a standard Windows build, regardless of the local platform or environment used by developers.

Next step if figuring out how to do the actual GitHub release, based on the CI build artifacts, and triggered by a new tag being pushed to the repository.

Edit: For an example of where the artifacts can be found:
https://ci.appveyor.com/project/OPU/leveltemplate/builds/29027347/job/47nj26u98d5icoqu/artifacts
