### PR TITLE
Add GitHub deploy task for tagged builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,3 +14,12 @@ after_build:
 artifacts:
   - path: "*.zip"
     name: BuildArtifacts
+deploy:
+  on:
+    branch: master
+    APPVEYOR_REPO_TAG: true
+  artifact: BuildArtifacts
+  description: ''
+  provider: GitHub
+  auth_token:
+    secure: TmV7XiO84JvSaLJnbrRrtoOugcFLSogA4I55yBZ1Y+QAmv28EOgO1M8lX+NSJWA/


### PR DESCRIPTION
Ok, I think I've got this figured out now. To create a new GitHub release, it should be as simple as creating a new Git `tag` for a commit on `master`, and then pushing the tag up to GitHub. You may also want to edit the release description on GitHub, as it will be left empty according to the current config.

Linux example:
```
# On branch master
git tag v1.0.0
git push -u origin v1.0.0
```

----

How it works:

GitHub access token: (Organization config, can be re-used for multiple projects)
A GitHub personal access token was created at: https://github.com/settings/tokens
The token needs permissions: `repo_deployment`, `public_repo`  ([Available scopes](https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/#available-scopes))
The GitHub token was copied and uploaded to AppVeyor at: https://ci.appveyor.com/tools/encrypt
The resulting encrypted value can be placed in `.appveyor.yml` for deployment

For `.appveyor.yml` deployment: (Project config)
The config checks the commit is on the `master` branch
The config checks the commit is a `tag` (should use format like `v1.0.0`, but not required)
If that's all good, and the encrypted deploy key is valid, with proper assigned permissions, the build artifacts will be uploaded as a [GitHub release](https://github.com/OutpostUniverse/LevelTemplate/releases).
A description may then be set for the release.

----

Due to the branch guard, this will need to be merged to master before creating and uploading a tag. You are free to merge and test this out if you want. To delete a release, you may need to first remove all binary file attachments.
