### PR TITLE
Auto release updates

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,13 +8,18 @@ install:
 build:
   project: OP2Script.sln
 after_build:
+  # Set version/build tag
   - set Version=Build%APPVEYOR_BUILD_VERSION%
   - if defined APPVEYOR_REPO_TAG_NAME set Version=%APPVEYOR_REPO_TAG_NAME%
+  # Set platform/configuration tag
   - set Config=%CONFIGURATION%
   - if defined PLATFORM set Config=%PLATFORM%-%Config%
+  # Set overall build tag
   - set PackageBaseName="%APPVEYOR_PROJECT_NAME%-%Version%-%Config%"
+  # Determine output folder
   - set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%PLATFORM%\%CONFIGURATION%\
   - if not exist "%OutputFolder%" set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\
+  # Package artifacts
   - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.dll"
   - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%OutputFolder%*.pdb"
 artifacts:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,7 +20,8 @@ after_build:
   - set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%PLATFORM%\%CONFIGURATION%\
   - if not exist "%OutputFolder%" set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\
   # Package artifacts
-  - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.dll"
+  - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.exe" "%OutputFolder%*.dll"
+  # - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.lib"
   - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%OutputFolder%*.pdb"
 artifacts:
   - path: "*.zip"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,9 @@ build:
 after_build:
   - set Version=Build%APPVEYOR_BUILD_VERSION%
   - if defined APPVEYOR_REPO_TAG_NAME set Version=%APPVEYOR_REPO_TAG_NAME%
-  - set PackageBaseName="%APPVEYOR_PROJECT_NAME%-%Version%-%CONFIGURATION%"
+  - set Config=%CONFIGURATION%
+  - if defined PLATFORM set Config=%PLATFORM%-%Config%
+  - set PackageBaseName="%APPVEYOR_PROJECT_NAME%-%Version%-%Config%"
   - 7z a "%PackageBaseName%.zip" "%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.dll"
   - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.pdb"
 artifacts:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,8 +13,10 @@ after_build:
   - set Config=%CONFIGURATION%
   - if defined PLATFORM set Config=%PLATFORM%-%Config%
   - set PackageBaseName="%APPVEYOR_PROJECT_NAME%-%Version%-%Config%"
-  - 7z a "%PackageBaseName%.zip" "%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.dll"
-  - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.pdb"
+  - set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%PLATFORM%\%CONFIGURATION%\
+  - if not exist "%OutputFolder%" set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\
+  - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.dll"
+  - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%OutputFolder%*.pdb"
 artifacts:
   - path: "*.zip"
     name: BuildArtifacts

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,6 +30,7 @@ deploy:
   on:
     branch: master
     APPVEYOR_REPO_TAG: true
+    CONFIGURATION: Release
   artifact: BuildArtifacts
   description: ''
   provider: GitHub

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,8 @@ install:
   - git submodule update --init --recursive
 build:
   project: OP2Script.sln
+
+# Config to automatically package build artifacts
 after_build:
   # Set version/build tag
   - set Version=Build%APPVEYOR_BUILD_VERSION%
@@ -26,6 +28,8 @@ after_build:
 artifacts:
   - path: "*.zip"
     name: BuildArtifacts
+
+# Config so tags automatically create GitHub releases and upload build artifacts
 deploy:
   on:
     branch: master

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,4 +35,5 @@ deploy:
   description: ''
   provider: GitHub
   auth_token:
+    # GitHub account specific
     secure: TmV7XiO84JvSaLJnbrRrtoOugcFLSogA4I55yBZ1Y+QAmv28EOgO1M8lX+NSJWA/

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,36 +8,41 @@ install:
 build:
   project: OP2Script.sln
 
-# Config to automatically package build artifacts
-after_build:
-  # Set version/build tag
-  - set Version=Build%APPVEYOR_BUILD_VERSION%
-  - if defined APPVEYOR_REPO_TAG_NAME set Version=%APPVEYOR_REPO_TAG_NAME%
-  # Set platform/configuration tag
-  - set Config=%CONFIGURATION%
-  - if defined PLATFORM set Config=%PLATFORM%-%Config%
-  # Set overall build tag
-  - set PackageBaseName="%APPVEYOR_PROJECT_NAME%-%Version%-%Config%"
-  # Determine output folder
-  - set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%PLATFORM%\%CONFIGURATION%\
-  - if not exist "%OutputFolder%" set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\
-  # Package artifacts
-  - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.exe" "%OutputFolder%*.dll"
-  # - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.lib"
-  - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%OutputFolder%*.pdb"
-artifacts:
-  - path: "*.zip"
-    name: BuildArtifacts
+# Derived projects may want to auto package build artifacts, and create GitHub
+# releases for tagged versions.
+# This is disabled for the LevelTemplate project itself, as it is just a
+# template project, and so has no binary release packages of its own.
 
-# Config so tags automatically create GitHub releases and upload build artifacts
-deploy:
-  on:
-    branch: master
-    APPVEYOR_REPO_TAG: true
-    CONFIGURATION: Release
-  artifact: BuildArtifacts
-  description: ''
-  provider: GitHub
-  auth_token:
-    # GitHub account specific
-    secure: TmV7XiO84JvSaLJnbrRrtoOugcFLSogA4I55yBZ1Y+QAmv28EOgO1M8lX+NSJWA/
+# # Config to automatically package build artifacts
+# after_build:
+#   # Set version/build tag
+#   - set Version=Build%APPVEYOR_BUILD_VERSION%
+#   - if defined APPVEYOR_REPO_TAG_NAME set Version=%APPVEYOR_REPO_TAG_NAME%
+#   # Set platform/configuration tag
+#   - set Config=%CONFIGURATION%
+#   - if defined PLATFORM set Config=%PLATFORM%-%Config%
+#   # Set overall build tag
+#   - set PackageBaseName="%APPVEYOR_PROJECT_NAME%-%Version%-%Config%"
+#   # Determine output folder
+#   - set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%PLATFORM%\%CONFIGURATION%\
+#   - if not exist "%OutputFolder%" set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\
+#   # Package artifacts
+#   - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.exe" "%OutputFolder%*.dll"
+#   # - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.lib"
+#   - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%OutputFolder%*.pdb"
+# artifacts:
+#   - path: "*.zip"
+#     name: BuildArtifacts
+#
+# # Config so tags automatically create GitHub releases and upload build artifacts
+# deploy:
+#   on:
+#     branch: master
+#     APPVEYOR_REPO_TAG: true
+#     CONFIGURATION: Release
+#   artifact: BuildArtifacts
+#   description: ''
+#   provider: GitHub
+#   auth_token:
+#     # GitHub account specific
+#     secure: TmV7XiO84JvSaLJnbrRrtoOugcFLSogA4I55yBZ1Y+QAmv28EOgO1M8lX+NSJWA/

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,9 @@ install:
 build:
   project: OP2Script.sln
 after_build:
-  - set PackageBaseName="%APPVEYOR_PROJECT_NAME%-Build%APPVEYOR_BUILD_VERSION%-%CONFIGURATION%"
+  - set Version=Build%APPVEYOR_BUILD_VERSION%
+  - if defined APPVEYOR_REPO_TAG_NAME set Version=%APPVEYOR_REPO_TAG_NAME%
+  - set PackageBaseName="%APPVEYOR_PROJECT_NAME%-%Version%-%CONFIGURATION%"
   - 7z a "%PackageBaseName%.zip" "%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.dll"
   - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\*.pdb"
 artifacts:


### PR DESCRIPTION
This closes #14.

It provides a template for auto packaging of build artifacts and auto creation of GitHub releases for tagged builds with upload of release packages. This would be useful to derived projects. It is commented out for the LevelTemplate project itself, as the LevelTemplate is just a source code template project, with no binary releases of its own.
